### PR TITLE
attributes for admission control enforcement

### DIFF
--- a/components/operators/rhacs-operator/instance/base/secured-cluster.yaml
+++ b/components/operators/rhacs-operator/instance/base/secured-cluster.yaml
@@ -7,11 +7,13 @@ metadata:
 spec:
   clusterName: local-cluster
   admissionControl:
-    listenOnCreates: false
+    contactImageScanners: ScanIfMissing
+    listenOnCreates: true
     listenOnEvents: true
-    listenOnUpdates: false
+    listenOnUpdates: true
+    timeoutSeconds: 10
   perNode:
     collector:
-      collection: EBPF
+      collection: CORE_BPF
       imageFlavor: Regular
     taintToleration: TolerateTaints


### PR DESCRIPTION
Changes to the default ACS admission control configuration:
- Enable listening (and enforcement) of policy on Deployment create, update, and edit verbs
- Lower the admission control timeout to 10 seconds to ensure that ACS doesn't cause Kube API timeouts
- Allow ACS to evaluate image contents (vulnerabilities) in Admission Control (fails open after timeoutSeconds)
- Change the collection method to CORE_BPF which will be the default method in ACS 4.4 and later