### PR TITLE
Update console-plugin.yaml

### DIFF
--- a/components/operators/gpu-operator-certified/operator/components/console-plugin/console-plugin.yaml
+++ b/components/operators/gpu-operator-certified/operator/components/console-plugin/console-plugin.yaml
@@ -15,8 +15,10 @@ metadata:
     app.kubernetes.io/part-of: console-plugin-nvidia-gpu
 spec:
   displayName: 'Console Plugin NVIDIA GPU Template'
-  service:
-    name: console-plugin-nvidia-gpu
-    namespace: nvidia-gpu-operator
-    port: 9443
-    basePath: '/'
+  backend:
+    service:
+      basePath: /
+      name: console-plugin-nvidia-gpu
+      namespace: nvidia-gpu-operator
+      port: 9443
+    type: Service


### PR DESCRIPTION
Updated to reflect that latest version of gpu operator requires "service" contents to be nested under "backend" along with "type: Service".